### PR TITLE
New/story controller

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,6 +10,8 @@ const { UsersController, TokensController, StoriesController } = require('./cont
 const app = express();
 
 // -- SERVERWIDE MIDDLEWARE -- //
+// TODO: export from app middleware
+// add errorHandler to req object
 app.use(
   bodyParser.json(),
   bodyParser.urlencoded({ extended: false }),

--- a/controllers/require-authed-user.js
+++ b/controllers/require-authed-user.js
@@ -1,4 +1,3 @@
-const jwt = require('jsonwebtoken');
 const { decryptID, verifyToken } = require('./tokens-controller/token-utils');
 
 /**

--- a/controllers/stories-controller/index.js
+++ b/controllers/stories-controller/index.js
@@ -1,43 +1,18 @@
 const express = require('express');
 const { requireAuthedUser } = require('../require-authed-user');
 const { latestStoriesHandler, newStoryHandler } = require('./stories-route-handlers');
-// TODO: implement
-// const {
-//   exchangeSlugForStory,
-//   storyNotFoundRedirect,
-//   StoryController,
-// } = require('./story-controller');
+const {
+  exchangeSlugForStory,
+  StoryController,
+} = require('./story-controller');
 
 const StoriesController = express.Router();
 
 StoriesController.get('/', latestStoriesHandler);
 StoriesController.post('/', requireAuthedUser, newStoryHandler);
 
-// TODO: implement
 // /stories/:storySlug/ Controller
-// StoriesController.use(
-//   '/:storySlug',
-//   exchangeSlugForStory,
-//   storyNotFoundRedirect,
-//   StoryController,
-// );
-
-// StoryController: /stories/:storySlug
-// GET: story
-// DELETE: authenticated -> delete story
-// PUT: authenticated -> update story
-// POST: /publish -> publish story
-
-  // ResponsesController: /stories/:storySlug/responses
-  // GET: story responses
-  // POST: respond to story
-  // DELETE: 
-
-  // ClapsController: /stories/:storySlug/claps
-  // GET: { clappedUser: [], readerClaps: Number }
-  // POST: clap for story
-  // PUT: update claps on clapped story
-  // DELETE: remove claps on story
+StoriesController.use('/:storySlug', exchangeSlugForStory, StoryController);
 
 // FUTURE: CategoriesController /stories/:category
 

--- a/controllers/stories-controller/stories-route-handlers.js
+++ b/controllers/stories-controller/stories-route-handlers.js
@@ -14,7 +14,8 @@ const newStoryHandler = async (req, res) => {
   
   const newStory = await models.Story.create({ title, body, author: authedUser });
   const responseShape = await newStory.toResponseShape();
-
+// TODO: 201 and location header to support REST spec
+// 
   return res.json(responseShape);
 };
 

--- a/controllers/stories-controller/story-controller/index.js
+++ b/controllers/stories-controller/story-controller/index.js
@@ -1,0 +1,33 @@
+const express = require('express');
+
+const { requireAuthedUser } = require('../../require-authed-user'); 
+const { exchangeSlugForStory, requireAuthorship } = require('./story-controller-middleware');
+const {
+  storyDiscoveryHandler,
+  storyUpdateHandler,
+  storyDeleteHandler,
+} = require('./story-controller-handlers');
+
+// Story Controller: /stories/:storySlug/
+const StoryController = express.Router();
+
+StoryController.get('/', storyDiscoveryHandler);
+StoryController.put('/', requireAuthedUser, requireAuthorship, storyUpdateHandler);
+StoryController.delete('/', requireAuthedUser, requireAuthorship, storyDeleteHandler);
+
+
+  // ResponsesController: /stories/:storySlug/responses
+  // GET: story responses
+  // POST: respond to story
+  // DELETE: 
+
+  // ClapsController: /stories/:storySlug/claps
+  // GET: { clappedUser: [], readerClaps: Number }
+  // POST: clap for story
+  // PUT: update claps on clapped story
+  // DELETE: remove claps on story
+
+module.exports = {
+  exchangeSlugForStory,
+  StoryController,
+};

--- a/controllers/stories-controller/story-controller/story-controller-middleware.js
+++ b/controllers/stories-controller/story-controller/story-controller-middleware.js
@@ -1,0 +1,28 @@
+const { extractStoryID } = require('./story-controller-utils');
+
+/**
+ * Processes a story slug from the path
+ * - injects req.pathStory property on success
+ * @requires req.storySlug: the slug to exchange
+ * @requires req.models DB models
+ * @param {Request} req Request object
+ * @param {Response} res Response object
+ * @param {Function} next next step function
+ * @returns {error} 400 JSON response if story slug is invalid
+ * @returns {error} 404 JSON response if a corresponding story is not found
+ */
+const exchangeSlugForStory = async (req, res, next) => {
+  const { params: { storySlug }, models } = req;
+  
+  const storyID = extractStoryID(storySlug);
+  if (!storyID) return res.status(400).json({ error: 'invalid story slug' });
+
+  const story = await models.Story.findById(storyID);
+  if (!story) return res.status(404).json({ error: 'story not found' });
+
+  req.pathStory = story;
+  next();
+};
+module.exports = {
+  exchangeSlugForStory,
+};

--- a/controllers/stories-controller/story-controller/story-controller-middleware.js
+++ b/controllers/stories-controller/story-controller/story-controller-middleware.js
@@ -23,6 +23,32 @@ const exchangeSlugForStory = async (req, res, next) => {
   req.pathStory = story;
   next();
 };
+
+/**
+ * Enforces the authed User is the author of the Story resource
+ * - proceeds and calls next() if the authed User is the author
+ * @requires req.autheduser: the authenticated User
+ * @requires req.pathStory: the story resource associated with this path
+ * @requires req.models DB models
+ * @param {Request} req Request object
+ * @param {Response} res Response object
+ * @param {Function} next next step function
+ * @returns {error} 401 JSON response if the authed User is not the author
+ */
+const requireAuthorship = (req, res, next) => {
+  const { authedUser, pathStory } = req;
+  
+  // author is an ObjectID type field
+  // instance.id uses the default ID getter which converts to string
+  // compare strings by calling toString on the author and default getter on authedUser
+  if (pathStory.author.toString() !== authedUser.id) {
+    return res.status(401).json({ error: 'authorship required' });
+  }
+
+  next();
+};
+
 module.exports = {
   exchangeSlugForStory,
+  requireAuthorship,
 };

--- a/controllers/stories-controller/story-controller/story-controller-utils.js
+++ b/controllers/stories-controller/story-controller/story-controller-utils.js
@@ -1,0 +1,35 @@
+const mongoose = require('mongoose');
+
+/**
+ * Validates an ID candidate to be a valid MongoDB ObjectID
+ * @param {string} id the ID to test
+ * @returns {string} success: ID converted to an ObjectID
+ * @returns {null} failure: null
+ */
+const validateObjectID = (id) => {
+  try {
+    return mongoose.Types.ObjectId(id);
+  }
+  catch(invalidTypeError) {
+    return null;
+  }
+};
+
+/**
+ * Extracts the Story ID from a story slug
+ * - calls validateObjectID before returning
+ * @param {string} storySlug a story slug from a request
+ * @returns {string} successful extraction: storyID
+ * @returns {null} unsuccessful extraction: null
+ */
+const extractStoryID = (storySlug) => {
+  const slugSplit = storySlug.split('-');
+  const storyID = slugSplit[slugSplit.length - 1];
+
+  return validateObjectID(storyID);
+};
+
+module.exports = {
+  validateObjectID,
+  extractStoryID,
+};

--- a/controllers/stories-controller/story-controller/story-route-handlers.js
+++ b/controllers/stories-controller/story-controller/story-route-handlers.js
@@ -1,0 +1,68 @@
+/**
+ * Handler for discovering an individual Story
+ * @param {Request} req Request object 
+ * @param req.pathStory: The story associated with this request path
+ * @param {Response} res Response object
+ * @returns JSON response with a Story Response Shape 
+ */
+const storyDiscoveryHandler = async (req, res) => {
+  const { pathStory } = req;
+
+  const response = await pathStory.toResponseShape();
+  return res.json(response);
+};
+
+/**
+ * Handler for updating a Story
+ * - updates one or more of { title, body, published }
+ * @requires Authentication and authorship
+ * @param {Request} req Request object 
+ * @param {Story} req.pathStory The story to be updated
+ * @param {string} req.body.title [optional] A new title for the story
+ * @param {string} req.body.body [optional]  A new body for the story
+ * @param {boolean} req.body.published [optional]  Sets the published field value
+ * @param {Response} res Response object
+ * @returns JSON response with the updated story in Story Response Shape
+ */
+const storyUpdateHandler = async (req, res) => {
+  const { pathStory, body: { title, body, published } } = req;
+  
+  const updateData = {};
+  if (title) updateData.title = title;
+  if (body) updateData.body = body;
+  if (published !== undefined) updateData.published = published;
+  
+  const updatedStory = await pathStory.update(updateData);
+  const response = await updatedStory.toResponseShape();
+  
+  return res.json(response);
+}; 
+
+/**
+ * Handler for deleting a Story
+ * - verifies the password of the authenticated user before deleting
+ * @requires Authentication and authorship
+ * @param {Request} req Request object 
+ * @param {Story} req.pathStory The story to be deleted
+ * @param {User} req.authedUser The authenticated User (author)
+ * @param {string} req.body.password Author's password for final verification
+ * @param {Response} res Response object
+ * @returns password verification fails: 401 JSON response { error }
+ * @returns password verification succeeds: 204 (no-content) response
+ */
+const storyDeleteHandler = async (req, res) => {
+  const { pathStory, authedUser, body: { password } } = req;
+
+  const verified = await authedUser.verifyPassword(password);
+  if (!verified) return res.status(401).json({ error: 'failed to authenticate' });
+
+  await pathStory.destroy();
+
+  return res.status(204); // success + no content
+};
+
+module.exports = {
+  storyDiscoveryHandler,
+  storyUpdateHandler,
+  storyDeleteHandler,
+};

--- a/controllers/stories-controller/story-controller/tests/story-controller-middleware.test.js
+++ b/controllers/stories-controller/story-controller/tests/story-controller-middleware.test.js
@@ -1,0 +1,53 @@
+const { extractStoryID } = require('../story-controller-utils');
+const { exchangeSlugForStory } = require('../story-controller-middleware');
+
+jest.mock('../story-controller-utils', () => ({ extractStoryID: jest.fn() }));
+
+const resMock = {
+  status: jest.fn(() => resMock),
+  json: jest.fn(),
+};
+
+const StoryMock = { findById: jest.fn() };
+
+const reqMockBase = { models: { Story: StoryMock } };
+
+describe('Story Controller middleware', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  describe('exchangeSlugForStory', () => {
+    test('storySlug does not contain a valid story ID: 400 JSON response { error: "invalid story slug" }', async () => {
+      const reqMock = { ...reqMockBase, params: { storySlug: 'im-a-bad-sluggie' } };
+      extractStoryID.mockImplementation(() => null);
+
+      await exchangeSlugForStory(reqMock, resMock);
+      expect(resMock.status).toHaveBeenCalledWith(400);
+      expect(resMock.json).toHaveBeenCalledWith({ error: 'invalid story slug' });
+    });
+
+    test('story is not found: 404 JSON response { error: "story not found" }', async () => {
+      const reqMock = { ...reqMockBase, params: { storySlug: 'a-good-sluggie-thisIsAnIdISwear' } };
+      extractStoryID.mockImplementation(() => true);
+      StoryMock.findById.mockImplementation(() => null);
+
+      await exchangeSlugForStory(reqMock, resMock);
+      expect(resMock.status).toHaveBeenCalledWith(404);
+      expect(resMock.json).toHaveBeenCalledWith({ error: 'story not found' });
+
+    });
+
+    test('story is found from slug: next() called and req.pathStory contains matching Story', async () => {
+      const mockStory = { id: 'aRealId' };
+      const reqMock = { ...reqMockBase, params: { storySlug: 'the-best-sluggie-andAnId' } };
+      extractStoryID.mockImplementation(() => mockStory.id);
+      StoryMock.findById.mockImplementation(() => mockStory);
+
+      const nextMock = jest.fn();
+
+      await exchangeSlugForStory(reqMock, null, nextMock);
+      expect(StoryMock.findById).toHaveBeenCalledWith(mockStory.id);
+      expect(nextMock).toHaveBeenCalled();
+      expect(reqMock.pathStory).toBe(mockStory)
+    });
+  });
+});

--- a/controllers/stories-controller/story-controller/tests/story-controller-utils.test.js
+++ b/controllers/stories-controller/story-controller/tests/story-controller-utils.test.js
@@ -1,0 +1,33 @@
+const mongoose = require('mongoose');
+const { validateObjectID, extractStoryID } = require('../story-controller-utils');
+
+describe('Story Controller utilities', () => {
+  describe('validateObjectID(): validates a candidate ID', () => {
+    test('valid ObjectID: returns the ID as an Object ID', () => {
+      const id = new mongoose.Types.ObjectId();
+      const output = validateObjectID(id)
+      expect(output).toBe(id);
+      expect(output.constructor.name).toBe('ObjectID');
+    });
+
+    test('invalid ObjectID: returns null', () => {
+      const id = 'not an id';
+      expect(validateObjectID(id)).toBeNull();
+    });
+  });
+
+  describe('extractStoryID(): extracts the story ID from a story slug', () => {
+    test('valid story slug: returns the extracted story ID as an Object ID', () => {
+      const id = new mongoose.Types.ObjectId();
+      const storySlug = `this-is-an-awesome-title-${id}`;
+      const output = extractStoryID(storySlug);
+      expect(output).not.toBeNull();
+    });
+
+    test('invalid story slug: returns null', () => {
+      const storySlug = 'this-is-a-bad-sluggie-';
+      const output = extractStoryID(storySlug);
+      expect(output).toBeNull();
+    });
+  });
+});

--- a/controllers/stories-controller/story-controller/tests/story-route-handlers.test.js
+++ b/controllers/stories-controller/story-controller/tests/story-route-handlers.test.js
@@ -1,0 +1,78 @@
+const { Story } = require('../../../../models');
+const {
+  storyDiscoveryHandler,
+  storyUpdateHandler,
+  storyDeleteHandler,
+  storyPublishHandler,
+} = require('../story-route-handlers');
+
+const resMock = {
+  status: jest.fn(() => resMock),
+  json: jest.fn(),
+};
+
+const storyMock = {
+  toResponseShape: jest.fn(), // already tested, can mock
+};
+
+describe('Story Controller route handlers', () => {
+  afterEach(() => jest.resetAllMocks());
+
+  test('storyDiscoveryHandler(): returns JSON response of pathStory in Story Response Shape', async () => {
+    const reqMock = { pathStory: storyMock };
+
+    await storyDiscoveryHandler(reqMock, resMock);
+    expect(storyMock.toResponseShape).toHaveBeenCalled();
+    expect(resMock.json).toHaveBeenCalledWith(storyMock.toResponseShape());
+  });
+
+  describe('storyUpdateHandler(): manages updates to an existing story', () => {
+    const bodyMock = { title: 'a new title', body: 'a new body', published: false };
+    const storyBase = new Story({ title: 'original title', body: 'original body', published: true });
+    const pathStory = Object.assign(storyBase, { update: jest.fn() }, storyMock);
+    const updatedMock = data => Object.assign(new Story({ ...data }), storyMock);
+
+    test('given title: updates the title only', async () => {
+      const reqMock = { pathStory, body: { title: bodyMock.title } };
+      pathStory.update.mockImplementation(() => updatedMock(reqMock.body));
+
+      await storyUpdateHandler(reqMock, resMock);
+      expect(pathStory.update).toHaveBeenCalledWith({ title: bodyMock.title });
+    });
+
+    test('given body: updates the body only', async () => {
+      const reqMock = { pathStory, body: { body: bodyMock.body } };
+      pathStory.update.mockImplementation(() => updatedMock(reqMock.body));
+      
+      await storyUpdateHandler(reqMock, resMock);
+      expect(pathStory.update).toHaveBeenCalledWith({ body: bodyMock.body });
+    });
+
+    test('given published: updates the published field only', async () => {
+      const reqMock = { pathStory, body: { published: bodyMock.published } };
+      pathStory.update.mockImplementation(() => updatedMock(reqMock.body));
+      
+      await storyUpdateHandler(reqMock, resMock);
+      expect(pathStory.update).toHaveBeenCalledWith({ published: bodyMock.published });
+    });
+
+    test('given all three: updates all three fields', async () => {
+      const reqMock = { pathStory, body: bodyMock };
+      pathStory.update.mockImplementation(() => updatedMock(bodyMock));
+      
+      await storyUpdateHandler(reqMock, resMock);
+      expect(pathStory.update).toHaveBeenCalledWith(bodyMock);
+    });
+
+    test('returns a JSON response with the updated story in Story Response Shape', async () => {
+      const reqMock = { pathStory, body: bodyMock };
+      const updated = updatedMock(bodyMock);
+      pathStory.update.mockImplementation(() => updated);
+
+      await storyUpdateHandler(reqMock, resMock);
+      expect(updated.toResponseShape).toHaveBeenCalled();
+      expect(resMock.json).toHaveBeenCalledWith(updated.toResponseShape());
+    });
+  });
+});
+ 

--- a/controllers/stories-controller/story-controller/tests/story-route-handlers.test.js
+++ b/controllers/stories-controller/story-controller/tests/story-route-handlers.test.js
@@ -3,7 +3,6 @@ const {
   storyDiscoveryHandler,
   storyUpdateHandler,
   storyDeleteHandler,
-  storyPublishHandler,
 } = require('../story-route-handlers');
 
 const resMock = {
@@ -16,7 +15,7 @@ const storyMock = {
 };
 
 describe('Story Controller route handlers', () => {
-  afterEach(() => jest.resetAllMocks());
+  afterEach(() => jest.clearAllMocks());
 
   test('storyDiscoveryHandler(): returns JSON response of pathStory in Story Response Shape', async () => {
     const reqMock = { pathStory: storyMock };
@@ -72,6 +71,38 @@ describe('Story Controller route handlers', () => {
       await storyUpdateHandler(reqMock, resMock);
       expect(updated.toResponseShape).toHaveBeenCalled();
       expect(resMock.json).toHaveBeenCalledWith(updated.toResponseShape());
+    });
+  });
+
+  describe('storyDeleteHandler(): deletes a Story', () => {
+    const authedUserMock = { verifyPassword: jest.fn() };
+    const toDeleteMock = { destroy: jest.fn() };
+
+    test('no password provided: returns 401 JSON response with { error: "failed to authenticate" }', async () => {
+      const reqMock = { pathStory: toDeleteMock, authedUser: authedUserMock, body: {} };
+      authedUserMock.verifyPassword.mockImplementation(() => false);
+
+      await storyDeleteHandler(reqMock, resMock);
+      expect(resMock.status).toHaveBeenCalledWith(401);
+      expect(resMock.json).toHaveBeenCalledWith({ error: 'failed to authenticate' });
+    });
+
+    test('invalid password provided: returns 401 JSON response with { error: "failed to authenticate" }', async () => {
+      const reqMock = { pathStory: toDeleteMock, authedUser: authedUserMock, body: {} };
+      authedUserMock.verifyPassword.mockImplementation(() => false);
+
+      await storyDeleteHandler(reqMock, resMock);
+      expect(resMock.status).toHaveBeenCalledWith(401);
+      expect(resMock.json).toHaveBeenCalledWith({ error: 'failed to authenticate' });
+    });
+
+    test('valid password provided: deletes the story and responds with a 201 status code', async () => {
+      const reqMock = { pathStory: toDeleteMock, authedUser: authedUserMock, body: { password: 'a secret one' } };
+      authedUserMock.verifyPassword.mockImplementation(() => true);
+
+      await storyDeleteHandler(reqMock, resMock);
+      expect(toDeleteMock.destroy).toHaveBeenCalled();
+      expect(resMock.status).toHaveBeenCalledWith(204);
     });
   });
 });

--- a/controllers/users-controller/index.js
+++ b/controllers/users-controller/index.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const { verifyPayload, checkDuplicate, registerUser } = require('./user-registration');
-const { exchangeSlugForUser, userNotFoundRedirect, UserController, } = require('./user-controller');
+const { exchangeSlugForUser, UserController, } = require('./user-controller');
 
 const UsersController = express.Router();
 
@@ -16,7 +16,6 @@ UsersController.post(
 UsersController.use(
   '/:usernameSlug',
   exchangeSlugForUser,
-  userNotFoundRedirect,
   UserController,
 );
 

--- a/controllers/users-controller/user-controller/index.js
+++ b/controllers/users-controller/user-controller/index.js
@@ -1,17 +1,23 @@
 const express = require('express');
-const routeHandlers = require('./user-route-handlers');
 const UserFollowersController = require('./user-follow-controller');
 const { exchangeSlugForUser } = require('./user-controller-middleware');
+const {
+  userDiscoveryHandler,
+  userStoriesHandler,
+  userResponsesHandler,
+  userFollowingHandler,
+  userClappedStoriesHandler,
+} = require('./user-route-handlers');
 
 // controls: /users/:usernameSlug/
 const UserController = express.Router();
 
-// UserController.get('/', userDiscoveryHandler);
-UserController.get('/stories', routeHandlers.stories);
+UserController.get('/', userDiscoveryHandler);
+UserController.get('/stories', userStoriesHandler);
+UserController.get('/responses', userResponsesHandler);
+UserController.get('/following', userFollowingHandler);
 UserController.use('/followers', UserFollowersController);
-UserController.get('/following', routeHandlers.following);
-UserController.get('/responses', routeHandlers.responses);
-UserController.get('/clapped', routeHandlers.clappedStories);
+UserController.get('/clapped', userClappedStoriesHandler);
 
 module.exports = {
   exchangeSlugForUser,

--- a/controllers/users-controller/user-controller/index.js
+++ b/controllers/users-controller/user-controller/index.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const routeHandlers = require('./user-route-handlers');
 const UserFollowersController = require('./user-follow-controller');
-const { exchangeSlugForUser, userNotFoundRedirect } = require('./user-controller-middleware');
+const { exchangeSlugForUser } = require('./user-controller-middleware');
 
 // controls: /users/:usernameSlug/
 const UserController = express.Router();
@@ -15,6 +15,5 @@ UserController.get('/clapped', routeHandlers.clappedStories);
 
 module.exports = {
   exchangeSlugForUser,
-  userNotFoundRedirect,
   UserController,
 };

--- a/controllers/users-controller/user-controller/tests/user-route-handlers.test.js
+++ b/controllers/users-controller/user-controller/tests/user-route-handlers.test.js
@@ -4,6 +4,7 @@ const models = require('../../../../models');
 const { dbConnect, setup, teardown, mocks: { storyMock } } = require('../../../../test-utils');
 const routeHandlers = require('../user-route-handlers');
 
+// TODO: Refactor using mocks
 describe('[/user/@username] Route Handlers', () => {
   let pathUser;
   let clapped;
@@ -52,7 +53,7 @@ describe('[/user/@username] Route Handlers', () => {
     let routeResponse;
     beforeAll(async () => {
       mockRes = { json: (data) => data };
-      routeResponse = await routeHandlers.stories({ pathUser, query: {} }, mockRes);
+      routeResponse = await routeHandlers.userStoriesHandler({ pathUser, query: {} }, mockRes);
     });
 
     test('returns the User Stories Response shape, fields: ["stories", "pagination"]', () => {
@@ -74,7 +75,7 @@ describe('[/user/@username] Route Handlers', () => {
     let routeResponse;
     beforeAll(async () => {
       mockRes = { json: data => data };
-      routeResponse = await routeHandlers.responses({ pathUser, query: {} }, mockRes);
+      routeResponse = await routeHandlers.userResponsesHandler({ pathUser, query: {} }, mockRes);
     });
 
     test('returns the User story Responses Response shape, fields: ["responses", "pagination"]', () => {

--- a/controllers/users-controller/user-controller/user-controller-middleware.js
+++ b/controllers/users-controller/user-controller/user-controller-middleware.js
@@ -1,20 +1,31 @@
-const exchangeSlugForUser = async (req, _, next) => {
+/**
+ * Processes a user slug from the path
+ * - injects req.pathUser property on success
+ * @requires req.usernameSlug: the slug to exchange
+ * @requires req.models DB models
+ * @param {Request} req Request object
+ * @param {Response} res Response object
+ * @param {Function} next next step function
+ * @returns {error} 400 JSON response if username slug is invalid
+ * @returns {error} 404 JSON response if a corresponding user is not found
+ */
+const 
+const exchangeSlugForUser = async (req, res, next) => {
   const { params: { usernameSlug }, models } = req;
-  const username = usernameSlug.replace('@', ''); // remove @ character from slug
 
-  // add the 'pathUser' property to the req object for use downstream
-  // this is the user with the username from the path /user/@username/
-  req.pathUser = await models.User.findOne({ username });
+  const username = usernameSlug.replace('@', '');
+  if (username.length !== usernameSlug.length - 1) {
+    // usernameSlug did not begin with @ or had multiple @ chars: invalid
+    return res.status(400).json({ error: 'invalid username' });
+  }
+
+  const user = await models.User.findOne({ username });
+  if (!user) return res.status(404).json({ error: 'user not found' });
+  
+  req.pathUser = user;
   next();
-};
-
-const userNotFoundRedirect = (req, res, next) => {
-  // if the path user is not found return a 404
-  if (!req.pathUser) return res.status(404).json({ error: 'user not found' });
-  next(); // otherwise proceeed to next handler
 };
 
 module.exports = {
   exchangeSlugForUser,
-  userNotFoundRedirect,
 };

--- a/controllers/users-controller/user-controller/user-controller-middleware.js
+++ b/controllers/users-controller/user-controller/user-controller-middleware.js
@@ -9,7 +9,6 @@
  * @returns {error} 400 JSON response if username slug is invalid
  * @returns {error} 404 JSON response if a corresponding user is not found
  */
-const 
 const exchangeSlugForUser = async (req, res, next) => {
   const { params: { usernameSlug }, models } = req;
 

--- a/controllers/users-controller/user-controller/user-route-handlers.js
+++ b/controllers/users-controller/user-controller/user-route-handlers.js
@@ -1,30 +1,36 @@
 // /user/@username/
+// TODO: test userDiscovery and add JSDocs to all
+const userDiscoveryHandler = async (req, res) => {
+  const { pathUser } = req;
+  return res.json(pathUser.toResponseShape());
+};
 
-const stories = ({ query: { limit, currentPage }, pathUser }, res) => pathUser
+const userStoriesHandler = ({ query: { limit, currentPage }, pathUser }, res) => pathUser
   .getStories({ limit, currentPage, onlyStories: true })
   .then(stories => pathUser.shapeAuthoredStories(stories))
   .then(stories => pathUser.addStoriesPagination({ stories, limit, currentPage }))
   .then(shapedStories => res.json(shapedStories))
   .catch(console.error);
 
-const responses = ({ query: { limit, currentPage }, pathUser }, res) => pathUser
+const userResponsesHandler = ({ query: { limit, currentPage }, pathUser }, res) => pathUser
   .getStories({ limit, currentPage, onlyResponses: true })
   .then(responses => pathUser.shapeAuthoredStories(responses))
   .then(responses => pathUser.addStoriesPagination({ responses, limit, currentPage }))
   .then(shapedResponses => res.json(shapedResponses))
   .catch(console.error);
 
-const following = ({ pathUser }, res) => pathUser.getFollowing()
+const userFollowingHandler = ({ pathUser }, res) => pathUser.getFollowing()
   .then(res.json)
   .catch(console.error);
 
-const clappedStories = ({ pathUser }, res) => pathUser.getClappedStories()
+const userClappedStoriesHandler = ({ pathUser }, res) => pathUser.getClappedStories()
   .then(res.json)
   .catch(console.error);
 
 module.exports = {
-  stories,
-  following,
-  responses,
-  clappedStories,
+  userDiscoveryHandler,
+  userStoriesHandler,
+  userResponsesHandler,
+  userFollowingHandler,
+  userClappedStoriesHandler,
 };

--- a/models/user/user-instance-methods/tests/user-instance-queries.test.js
+++ b/models/user/user-instance-methods/tests/user-instance-queries.test.js
@@ -130,5 +130,11 @@ describe('User Model Instance Methods: Queries', () => {
       const isValid = await user.verifyPassword('this aint it chief');
       expect(isValid).toBe(false);
     });
+
+    test('returns false if undefined is passed as a password', async () => {
+      let undefinedPassword;
+      const isValid = await user.verifyPassword(undefinedPassword);
+      expect(isValid).toBe(false);
+    });
   });
 });

--- a/models/user/user-instance-methods/user-instance-queries.js
+++ b/models/user/user-instance-methods/user-instance-queries.js
@@ -70,6 +70,7 @@ function getClappedStories(limit, currentPage) {
  * @returns resolves true or false
  */
 async function verifyPassword(passwordAttempt) {
+  if (!passwordAttempt) return false;
   return bcrypt.compare(passwordAttempt, this.password);
 }
 


### PR DESCRIPTION
Story Controller for `/stories/:storySlug/`
- GET: individual Story discovery
- PUT: update a story
- DELETE: delete a story

User Controller
- combined middleware and refactored tests
- renamed handlers to be consistent with Story controller handlers and refactored tests
- add userDiscoveryHandler for individual user access

Middleware
- exchangeSlugForStory
- requireAuthorship

Utils
- validateObjectID
- extractStoryID

User instance queries
- add verifyPassword support for undefined password